### PR TITLE
mkdirs create intermediate directories as required

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -107,8 +107,13 @@ class Client(object):
         old_cwd = self.cwd
         try:
             for dir in dirs:
-                self.mkdir(dir, safe=True)
-                self.cd(dir)
+                try:
+                    self.mkdir(dir, safe=True)
+                except Exception as e:
+                    if e.actual_code == 409:
+                        raise
+                finally:
+                    self.cd(dir)
         finally:
             self.cd(old_cwd)
     def rmdir(self, path, safe=False):


### PR DESCRIPTION
When directory exits, change to this directory and create next directory in path. If trying to create a directory that exists as a file it will raise an exception '409 Conflict'
