### PR TITLE
Add the option to NOT verify the ssl certificate

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -62,12 +62,13 @@ class OperationFailed(WebdavException):
 
 class Client(object):
     def __init__(self, host, port=0, auth=None, username=None, password=None,
-                 protocol='http'):
+                 protocol='http', verify_ssl=True):
         if not port:
             port = 443 if protocol == 'https' else 80
         self.baseurl = '{0}://{1}:{2}'.format(protocol, host ,port)
         self.cwd = '/'
         self.session = requests.session()
+        self.session.verify = verify_ssl
         if auth:
             self.session.auth = auth
         elif username and password:


### PR DESCRIPTION
Especially during development, and for internal usage it is sometimes nice to be able to use self signed https certificates. 
This patch adds a simple flag that is passed to the underlying requests library allowing the verification to be toggled at object creation time.
