### PR TITLE
add a path option for the webdav server

### DIFF
--- a/easywebdav/__init__.py
+++ b/easywebdav/__init__.py
@@ -1,5 +1,5 @@
 from client import *
 
 def connect(*args, **kwargs):
-    """connect(host, port=0, auth=None, username=None, password=None, protocol='http')"""
+    """connect(host, port=0, auth=None, username=None, password=None, protocol='http', path="/")"""
     return Client(*args, **kwargs)

--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -62,10 +62,10 @@ class OperationFailed(WebdavException):
 
 class Client(object):
     def __init__(self, host, port=0, auth=None, username=None, password=None,
-                 protocol='http'):
+                 protocol='http', path="/"):
         if not port:
             port = 443 if protocol == 'https' else 80
-        self.baseurl = '{0}://{1}:{2}'.format(protocol, host ,port)
+        self.baseurl = '{0}://{1}:{2}{3}'.format(protocol, host, port, path)
         self.cwd = '/'
         self.session = requests.session()
         if auth:


### PR DESCRIPTION
Some WebDAV servers have a path component to them (like the one supplied by ownCloud).  This adds an option to pass in a path to be appended to the `Client`'s `base_url`.
