### PR TITLE
Added 200 to ok results for PUT action

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -129,7 +129,7 @@ class Client(object):
         with open(local_path, 'rb') as f:
             self.put(f, remote_path)
     def put(self, file, remote_path):
-        self._send('PUT', remote_path, (201, 204), data=file.read())
+        self._send('PUT', remote_path, (200, 201, 204), data=file.read())
     def download(self, remote_path, local_path):
         response = self.open(remote_path)
         with open(local_path, 'wb') as f:


### PR DESCRIPTION
The server im working with is returning status 200 for successful PUT request. This also seems in accordance with http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html stating in section 9.6:

> If a new resource is created, the origin server MUST inform the user agent via the 201 (Created) response. If an existing resource is modified, either the 200 (OK) or 204 (No Content) response codes SHOULD be sent to indicate successful completion of the request. If the resource could not be created or modified with the Request-URI, an appropriate error response SHOULD be given that reflects the nature of the problem.

This patch simply adds the return code 200 to be accepted as success when PUTing things.
