### PR TITLE
Add support for client side ssl certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Features
 * Creating directories, removing directories and files
 * Uploading and downloading files
 * Directory listing
+* Support for client side SSL certificates
 
 Installation
 ------------
@@ -41,3 +42,17 @@ The API is pretty much self-explanatory:
     delete(file_path)
     upload(local_path, remote_path)
     download(remote_path, local_path)
+
+Using clientside SSL certificate
+--------------------------------
+
+    webdav = easywebdav.connect('secure.example.net',
+                                username='user',
+                                password='pass',
+                                protocol='https',
+                                cert="/path/to/your/certificate.pem")
+    # Do some stuff:
+    print webdav.ls()
+
+Please note that all options and restriction regarding the "cert" parameter from
+[Requests API](http://docs.python-requests.org/en/latest/api/) apply here as the parameter is only passed through!

--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -75,7 +75,7 @@ class OperationFailed(WebdavException):
 
 class Client(object):
     def __init__(self, host, port=0, auth=None, username=None, password=None,
-                 protocol='http', verify_ssl=True, path=None):
+                 protocol='http', verify_ssl=True, path=None, cert=None):
         if not port:
             port = 443 if protocol == 'https' else 80
         self.baseurl = '{0}://{1}:{2}'.format(protocol, host, port)
@@ -85,6 +85,10 @@ class Client(object):
         self.session = requests.session()
         self.session.verify = verify_ssl
         self.session.stream = True
+
+        if cert:
+            self.session.cert = cert
+
         if auth:
             self.session.auth = auth
         elif username and password:


### PR DESCRIPTION
This pull requests adds support for client side certificates. Due to the power of Requests/Urllib there is nothing much to do as all is handled in the libraries themselves.
