### PR TITLE
Fix handling empty property of WebDav object

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -31,7 +31,7 @@ File = namedtuple('File', ['name', 'size', 'mtime', 'ctime', 'contenttype'])
 
 def prop(elem, name, default=None):
     child = elem.find('.//{DAV:}' + name)
-    return default if child is None else child.text
+    return default if child is None or not child.text else child.text
 
 
 def elem2file(elem):


### PR DESCRIPTION
Folders on server may have size attribute represented as empty string. Hence, it's size cause crash while retrieving size of object via `int('')`.
