### PR TITLE
Py3 compatibility fix: aliasing basestring to str

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -13,6 +13,8 @@ else:
     from http.client import responses as HTTP_CODES
     from urllib.parse import urlparse
 
+    basestring = str
+
 DOWNLOAD_CHUNK_SIZE_BYTES = 1 * 1024 * 1024
 
 class WebdavException(Exception):


### PR DESCRIPTION
This fix prevents the following error when downloading into a filelike object:

``` python
....
  File "./wd.py", line 21, in find_and_download_newest_file
    data = c.download(matching_item.name, bio)
  File "/usr/local/lib/python3.4/dist-packages/easywebdav/client.py", line 164, in download
    if isinstance(local_path_or_fileobj, basestring):
NameError: name 'basestring' is not defined
```
