### PR TITLE
Include tests in release source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tests *.py


### PR DESCRIPTION
A test suite is a very useful thing, it would be great to include it in the
pypi release tarball. That way people who download and build the release can
run the tests to ensure the library is working.

Linux distributions, such as Debian, base their packages of Python modules on
the pypi release. This means the test suite can be run when building a Debian
package, it should catch mistakes in the packaging or errors in dependencies.

I've written some more on this topic on the Debian Python mailing list.

https://lists.debian.org/debian-python/2016/04/msg00074.html
